### PR TITLE
Fix unnecessary name updates

### DIFF
--- a/botto/MottoBotto.py
+++ b/botto/MottoBotto.py
@@ -111,7 +111,7 @@ class MottoBotto(discord.Client):
         member_record = self.members.match("Discord ID", member.id)
         if not member_record:
             return None
-        if member_record['fields'].get('Name') == member.display_name:
+        if member_record["fields"].get("Name") == member.display_name:
             return None
         update_dict = {
             "Name": member.display_name,

--- a/botto/MottoBotto.py
+++ b/botto/MottoBotto.py
@@ -101,7 +101,7 @@ class MottoBotto(discord.Client):
         return member_record
 
     def update_existing_member(
-        self, member: Member, emoji: Optional[str] = None
+        self, member: Member
     ) -> Optional[dict]:
         """
         Updates an existing member's record. This will not add new members
@@ -114,8 +114,6 @@ class MottoBotto(discord.Client):
         update_dict = {
             "Name": member.display_name,
         }
-        if emoji is not None:
-            update_dict["Emoji"] = emoji
         self.members.update(member_record["id"], update_dict)
         return member_record
 

--- a/botto/MottoBotto.py
+++ b/botto/MottoBotto.py
@@ -111,6 +111,8 @@ class MottoBotto(discord.Client):
         member_record = self.members.match("Discord ID", member.id)
         if not member_record:
             return None
+        if member_record['fields'].get('Name') == member.display_name:
+            return None
         update_dict = {
             "Name": member.display_name,
         }


### PR DESCRIPTION
Was previously sending name updates to Airtable even if the display name is the same as the one stored in Airtable