### PR TITLE
Name updates on message approval

### DIFF
--- a/botto/MottoBotto.py
+++ b/botto/MottoBotto.py
@@ -95,6 +95,12 @@ class MottoBotto(discord.Client):
             motto_record["id"], {"Motto": actual_motto, "Approved by Author": True}
         )
         await reactions.stored(self, message, motto_message)
+        
+        nominee = await self.get_or_add_member(motto_message.author)
+        nominator = await self.get_or_add_member(message.author)
+        await self.update_name(nominee, motto_message.author)
+        await self.update_name(nominator, message.author)
+
 
     async def on_message(self, message: Message):
 


### PR DESCRIPTION
Checks for name updates for both the nominator and nominee upon the message being successfully approved. Fixes #120 