### PR TITLE
Add git to bot docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-alpine
 LABEL org.opencontainers.image.source=https://github.com/Lovely-Development-Team/MottoBotto
 
-RUN apk add --no-cache gcc musl-dev
+RUN apk add --no-cache gcc musl-dev git
 
 COPY requirements.txt .
 


### PR DESCRIPTION
We need this to install a module directly from git.
Really should be done as a multi-stage build as we don't need it when running, but it's probably not a huge increase in image size.