### PR TITLE
Support Quotes in Plain Text

### DIFF
--- a/botto/MottoBotto.py
+++ b/botto/MottoBotto.py
@@ -153,10 +153,12 @@ class MottoBotto(discord.Client):
                     log.info(f"Ignoring approval on quoted exerpt {trigger_message_content!r} not found in existing message {motto_message.content!r}")
                     return
                 if plain_match:
-                    trigger_message_content = remove_markdown(trigger_message_content)
-                    actual_trigger_start = re.search("^\w+", trigger_message_content).group()
-                    actual_trigger_end = re.search("\S+$", trigger_message_content).group()
-                    trigger_message_content = re.search(actual_trigger_start + ".*" + actual_trigger_end, motto_message.content).group()
+                    plain_message_content = remove_markdown(trigger_message_content)
+                    actual_trigger_start = re.search("^\w+", plain_message_content).group()
+                    actual_trigger_end = re.search("\S+$", plain_message_content).group()
+                    formatted_content = re.search(actual_trigger_start + ".*" + actual_trigger_end, motto_message.content).group()
+                    if remove_markdown(formatted_content) is plain_message_content:
+                        trigger_message_content = formatted_content
                 actual_motto = self.clean_message(trigger_message_content, message.guild)
 
             else:

--- a/botto/MottoBotto.py
+++ b/botto/MottoBotto.py
@@ -156,7 +156,7 @@ class MottoBotto(discord.Client):
                     trigger_message_content = remove_markdown(trigger_message_content)
                     actual_trigger_start = re.search("^\w+", trigger_message_content).group()
                     actual_trigger_end = re.search("\S+$", trigger_message_content).group()
-                    trigger_message_content = re.search(actual_trigger_start + ".*" + actual_trigger_end, motto_message.content)
+                    trigger_message_content = re.search(actual_trigger_start + ".*" + actual_trigger_end, motto_message.content).group()
                 actual_motto = self.clean_message(trigger_message_content, message.guild)
 
             else:

--- a/botto/MottoBotto.py
+++ b/botto/MottoBotto.py
@@ -147,9 +147,16 @@ class MottoBotto(discord.Client):
             log.info(f"Trigger message content: {trigger_message_content!r}")
 
             if trigger_message_content:
-                if trigger_message_content not in motto_message.content or trigger_message_content not in remove_markdown(motto_message.content):
+                match = trigger_message_content in motto_message.content
+                plain_match = remove_markdown(trigger_message_content) in remove_markdown(motto_message.content)
+                if not match or not plain_match:
                     log.info(f"Ignoring approval on quoted exerpt {trigger_message_content!r} not found in existing message {motto_message.content!r}")
                     return
+                if plain_match:
+                    trigger_message_content = remove_markdown(trigger_message_content)
+                    actual_trigger_start = re.search("^\w+", trigger_message_content).group()
+                    actual_trigger_end = re.search("\S+$", trigger_message_content).group()
+                    trigger_message_content = re.search(actual_trigger_start + ".*" + actual_trigger_end, motto_message.content)
                 actual_motto = self.clean_message(trigger_message_content, message.guild)
 
             else:

--- a/botto/MottoBotto.py
+++ b/botto/MottoBotto.py
@@ -6,6 +6,7 @@ import datetime
 import re
 from typing import Optional
 
+from discord.utils import remove_markdown
 from emoji import UNICODE_EMOJI
 import subprocess
 
@@ -146,7 +147,7 @@ class MottoBotto(discord.Client):
             log.info(f"Trigger message content: {trigger_message_content!r}")
 
             if trigger_message_content:
-                if trigger_message_content not in motto_message.content:
+                if trigger_message_content not in motto_message.content or trigger_message_content not in remove_markdown(motto_message.content):
                     log.info(f"Ignoring approval on quoted exerpt {trigger_message_content!r} not found in existing message {motto_message.content!r}")
                     return
                 actual_motto = self.clean_message(trigger_message_content, message.guild)


### PR DESCRIPTION
If someone quotes a message but without the same formatting (and `_` and `*` can be used somewhat interchangeably, making this very hard), then it failed. This supports plain text comparisons.